### PR TITLE
feat: use conventional-commit-types to cover all commit types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "compare-func": "^1.3.1",
+    "conventional-commit-types": "^2.1.1",
     "q": "^1.4.1"
   }
 }

--- a/writer-opts.js
+++ b/writer-opts.js
@@ -4,6 +4,7 @@ const compareFunc = require(`compare-func`);
 const Q = require(`q`);
 const readFile = Q.denodeify(require(`fs`).readFile);
 const resolve = require(`path`).resolve;
+const conventionalCommitTypes = require(`conventional-commit-types`)
 
 module.exports = Q.all([
   readFile(resolve(__dirname, `./templates/template.hbs`), `utf-8`),
@@ -31,24 +32,9 @@ function getWriterOpts() {
         note.title = `BREAKING CHANGES`;
       });
 
-      if (commit.type === `feat`) {
-        commit.type = `Features`;
-      } else if (commit.type === `fix`) {
-        commit.type = `Bug Fixes`;
-      } else if (commit.type === `perf`) {
-        commit.type = `Performance Improvements`;
-      } else if (commit.type === `revert`) {
-        commit.type = `Reverts`;
-      } else if (commit.type === `docs`) {
-        commit.type = `Documentation`;
-      } else if (commit.type === `style`) {
-        commit.type = `Styles`;
-      } else if (commit.type === `refactor`) {
-        commit.type = `Code Refactoring`;
-      } else if (commit.type === `test`) {
-        commit.type = `Tests`;
-      } else if (commit.type === `chore`) {
-        commit.type = `Chores`;
+      const matchedType = conventionalCommitTypes.types[commit.type]
+      if (matchedType) {
+        commit.type = matchedType.title
       } else {
         return undefined; // ignore other type
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -250,6 +250,11 @@ conventional-changelog-writer@^2.0.3:
     split "^1.0.0"
     through2 "^2.0.0"
 
+conventional-commit-types@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/conventional-commit-types/-/conventional-commit-types-2.1.1.tgz#352eb53f56fbc7c1a6c1ba059c2b6670c90b2a8a"
+  integrity sha512-0Ts+fEdmjqYDOQ1yZ+LNgdSPO335XZw9qC10M7CxtLP3nIMGmeMhmkM8Taffa4+MXN13bRPlp0CtH+QfOzKTzw==
+
 conventional-commits-filter@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/conventional-commits-filter/-/conventional-commits-filter-1.1.1.tgz#72172319c0c88328a015b30686b55527b3a5e54a"


### PR DESCRIPTION
Updated to use https://github.com/commitizen/conventional-commit-types to cover all types dynamically.